### PR TITLE
feat: update chartscii and add value labels

### DIFF
--- a/main.js
+++ b/main.js
@@ -84,6 +84,7 @@ const chart = new chartscii(data, {
   height: 5,
   title: "Totals by year",
   fill: "░",
+  valueLabels: true,
 });
 
 console.log(chart.create());

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "chartscii": "^3.0.1",
+        "chartscii": "^3.1.0",
         "prettyjson": "^1.2.5",
         "yargs": "^17.7.2"
       }
@@ -33,11 +33,11 @@
       }
     },
     "node_modules/chartscii": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/chartscii/-/chartscii-3.0.1.tgz",
-      "integrity": "sha512-I7COXMWe9vcLht98B/uA9tjL1awltH327cGzd+X6rjemAu9k6CPiiRHVlap+0l6LbV/Vkyp7LfxeGJHf2d3ByQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/chartscii/-/chartscii-3.1.0.tgz",
+      "integrity": "sha512-Ebx4Gw10OX6JweIvHJsizgvChZI5ofTvosfocFOhFUCL7UiFede6FbdKN6qG5+Z5bcGCwAaae8imikR5sPVXvA==",
       "dependencies": {
-        "styl3": "^1.2.4"
+        "styl3": "3.1.1"
       }
     },
     "node_modules/cliui": {
@@ -159,9 +159,9 @@
       }
     },
     "node_modules/styl3": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/styl3/-/styl3-1.4.0.tgz",
-      "integrity": "sha512-RdUDaCy9POYkcAunRcGr+pu1eFcoE4kOQCEpm6Gd0bmTZUXSPzK1dgQOgrNOM9JdAb2/GY2gEUNJN8Hy+mr+8Q=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/styl3/-/styl3-3.1.1.tgz",
+      "integrity": "sha512-WRTBm/bs2ZfkbIQTk59xfJ0x/X4VKUSm/3u6egDFHNrYCcXYfWauBgq129whvYREvEOlOPQjDu1TARHyxCzCjQ=="
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "start": "node main.js"
   },
   "dependencies": {
-    "chartscii": "^3.0.1",
+    "chartscii": "^3.1.0",
     "prettyjson": "^1.2.5",
     "yargs": "^17.7.2"
   }


### PR DESCRIPTION
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L6-R6): The `chartscii` library version has been upgraded from `^3.0.1` to `^3.1.0`. This update brings in `valueLabels`.


* [`main.js`](diffhunk://#diff-58417e0f781b6656949d37258c8b9052ed266e2eb7a5163cad7b0863e6b2916aR87): The chart visualization has been improved by enabling value labels. This change will make the chart more informative as it will now display the values on the chart itself.