### PR TITLE
chore: switch chartscii dependency back upstream version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,6 @@ jobs:
       with:
         node-version: 22
         cache: 'npm'
-        registry-url: 'https://npm.pkg.github.com'
-        scope: '@joshjohanning'
-        always-auth: true
-      env:
-        NODE_AUTH_TOKEN: ${{ github.token }}
 
     - name: Install dependencies
       run: npm ci

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@joshjohanning:registry=https://npm.pkg.github.com

--- a/main.js
+++ b/main.js
@@ -3,7 +3,7 @@ const path = require("path");
 const prettyjson = require("prettyjson");
 const yargs = require("yargs/yargs");
 const { hideBin } = require("yargs/helpers");
-const chartscii = require("@joshjohanning/chartscii");
+const chartscii = require("chartscii");
 
 const argv = yargs(hideBin(process.argv)).option("dirPath", {
   type: "string",
@@ -123,7 +123,7 @@ const chart = new chartscii(expenseData, {
   fill: "░",
   valueLabels: true,
   valueLabelsPrefix: "$",
-  valueLabelsDecimalPlaces: 2
+  valueLabelsFloatingPoint: 2
 });
 
 const reimbursementChart = new chartscii(reimbursementData, {
@@ -133,7 +133,7 @@ const reimbursementChart = new chartscii(reimbursementData, {
   fill: "░",
   valueLabels: true,
   valueLabelsPrefix: "$",
-  valueLabelsDecimalPlaces: 2
+  valueLabelsFloatingPoint: 2
 });
 
 console.log(chart.create());

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,18 +7,9 @@
     "": {
       "version": "0.1.0",
       "dependencies": {
-        "@joshjohanning/chartscii": "^3.2.0",
+        "chartscii": "^3.2.0",
         "prettyjson": "^1.2.5",
         "yargs": "^17.7.2"
-      }
-    },
-    "node_modules/@joshjohanning/chartscii": {
-      "version": "3.2.0",
-      "resolved": "https://npm.pkg.github.com/download/@joshjohanning/chartscii/3.2.0/bb5fef73f3bf23fa9122d85bdfb5e8fd0629dfeb",
-      "integrity": "sha512-cD3UGmQTeyV8Y5AK+2bp5Pruy+oNPbQZdBP1Ui7MvAA7MlRh5mkgrmUty/i/wzXkFXLzBWokie2zJKpmK1B3BA==",
-      "license": "MIT",
-      "dependencies": {
-        "styl3": "3.1.1"
       }
     },
     "node_modules/ansi-regex": {
@@ -43,6 +34,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/chartscii": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/chartscii/-/chartscii-3.2.0.tgz",
+      "integrity": "sha512-O70q5XQzB/R5ekwz8roqPO1grQSTTsO6t7UmOmofY5E9vcV4k1N35aiVNumN0SnyYnBgk+JgQFXq30+jdUJXuA==",
+      "license": "MIT",
+      "dependencies": {
+        "styl3": "3.1.1"
       }
     },
     "node_modules/cliui": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "test": "node main.js --dirPath=./test-data"
   },
   "dependencies": {
-    "@joshjohanning/chartscii": "^3.2.0",
+    "chartscii": "^3.2.0",
     "prettyjson": "^1.2.5",
     "yargs": "^17.7.2"
   }


### PR DESCRIPTION
Replace the fork with the upstream now that the value label floating point and value label prefix PR has been merged in