### PR TITLE
ci: ensure version check runs only on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
         fetch-depth: 0
 
     - name: Check version increment
+      if: github.event_name == 'pull_request'
       run: |
         # Check if this is a PR and get the files changed
         if [ "${{ github.event_name }}" = "pull_request" ]; then


### PR DESCRIPTION
The version check only needs to run on PRs. 