### PR TITLE
ci: strip ANSI codes from test results before publishing to job summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,8 +80,9 @@ jobs:
     - name: Run application
       run: npm run test | tee results.log
 
-    - name: Publish to job summary
+    - name: Strip ANSI codes and publish to job summary
       run: |
         echo '```' >> $GITHUB_STEP_SUMMARY
-        cat results.log >> $GITHUB_STEP_SUMMARY
+        # Strip ANSI escape sequences from the output
+        sed 's/\x1b\[[0-9;]*m//g' results.log >> $GITHUB_STEP_SUMMARY
         echo '```' >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Fix what we are seeing with this:

```
Expenses by year
2021 �[0m╢██████░░░░░░░░░░░░░░ $75.00
2022 �[0m╢████████████████████ $250.00
2023 �[0m╢████████░░░░░░░░░░░░ $100.00
2024 �[0m╢████░░░░░░░░░░░░░░░░ $50.00
2025 �[0m╢██████████░░░░░░░░░░ $125.00
     ╚════════════════════
```