### PR TITLE
ci: add GitHub Actions workflow for publishing packages to NPM and GitHub Packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,76 @@
+name: Publish Package
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      npm:
+        description: 'Publish to NPM'
+        type: boolean
+        default: false
+      gh:
+        description: 'Publish to GitHub Packages'
+        type: boolean
+        default: true
+
+jobs:
+  publish_npm:
+    if: ${{ github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.npm) }}
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: NPM publish
+        run: npm publish --provenance --access public
+
+  publish_gh:
+    if: ${{ github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.gh) }}
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: 'https://npm.pkg.github.com'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: GitHub Packages publish
+        run: npm publish --access public


### PR DESCRIPTION
**New publishing workflow:**

* Added `.github/workflows/publish.yml` to automate package publishing to NPM and GitHub Packages, triggered by release creation or manual dispatch with configurable inputs.
