### PR TITLE
fix(ci): remove predicate-type from attest step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,7 +43,6 @@ jobs:
         uses: actions/attest@v4
         with:
           subject-path: '*.tgz'
-          predicate-type: 'https://slsa.dev/provenance/v1'
 
       - name: Upload tarball
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
actions/attest@v4 auto-generates build provenance when only `subject-path` is provided. Specifying `predicate-type` without a `predicate` causes the action to fail with: `One of predicate-path or predicate must be provided`.